### PR TITLE
最後のページのエンティティを削除するとエラーになるのを修正

### DIFF
--- a/packages/ui/src/pages/sheet/SheetPage.tsx
+++ b/packages/ui/src/pages/sheet/SheetPage.tsx
@@ -31,6 +31,7 @@ import { useTableLocalization } from './hooks/TableLocalizationHook'
 import { ActionContextProvider } from './hooks/ActionContextHook'
 import { ActionDialog } from './components/ActionDialog'
 import { useTableActions } from './hooks/TableActionsHook'
+import { useRefreshTable } from './hooks/RefreshTableHook'
 
 const tableOptions: TableOptions = {
   pageSize: 10,
@@ -63,17 +64,20 @@ export const SheetPage: FC = () => {
   )
 }
 
+type TableRef = {
+  onChangePage: (event: any, page: number) => void
+  onQueryChange: () => void
+}
+
 const SheetPageTable: FC<{ sheet: SheetOverview; user: IAMUserEntity }> = ({
   sheet,
 }) => {
-  const tableRef = useRef<{ onQueryChange: () => void }>()
+  const tableRef = useRef<TableRef>()
   const { result: info, trigger, error } = useSheetInfoContext()
   const queryEntities = useQueryEntities(sheet.sheetName)
   const { isEditable, onRowUpdate, onRowAdd } = useEditEntity(info)
-  const { actions, onSelectionChange } = useTableActions(
-    info,
-    tableRef.current?.onQueryChange ?? (() => null),
-  )
+  const refreshTable = useRefreshTable(tableRef.current)
+  const { actions, onSelectionChange } = useTableActions(info, refreshTable)
   const uiPaths = useUIPaths()
   useEffect(() => {
     trigger(sheet.sheetName)

--- a/packages/ui/src/pages/sheet/hooks/RefreshTableHook.tsx
+++ b/packages/ui/src/pages/sheet/hooks/RefreshTableHook.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+
+export type TableRef = {
+  onChangePage: (event: any, page: number) => void
+  onQueryChange: () => void
+}
+
+export type RefreshTable = (page?: number) => void
+
+export const useRefreshTable = (tableRef?: TableRef): RefreshTable => {
+  const refreshTable = useCallback(
+    (page?: number) => {
+      if (tableRef) {
+        if (typeof page === 'number') {
+          tableRef.onChangePage(null, page)
+        } else {
+          tableRef.onQueryChange()
+        }
+      }
+    },
+    [tableRef],
+  )
+  return refreshTable
+}

--- a/packages/ui/src/pages/sheet/hooks/TableActionsHook.ts
+++ b/packages/ui/src/pages/sheet/hooks/TableActionsHook.ts
@@ -12,7 +12,7 @@ import { useActionContext } from './ActionContextHook'
 
 export const useTableActions = (
   sheet: SheetInfo | null,
-  refreshTable: () => void,
+  refreshTable: (page?: number) => void,
 ): {
   actions: TableAction<Entity>[]
   onSelectionChange: (entities: Entity[]) => void
@@ -41,7 +41,7 @@ export const useTableActions = (
               enqueueSnackbar(l.snackbars.deleteComplete, {
                 variant: 'success',
               })
-              refreshTable()
+              refreshTable(0)
             } catch (e) {
               console.error(e)
               enqueueSnackbar(l.snackbars.deleteFailed, {


### PR DESCRIPTION
material-table の不具合 https://github.com/mbrn/material-table/issues/537

削除時に最初のページに戻るようにした。